### PR TITLE
Fix password reset to redirect to dedicated security page

### DIFF
--- a/js/App.js
+++ b/js/App.js
@@ -274,7 +274,7 @@ export const App = () => {
             key: "main",
             className: "flex-grow"
         }, renderPage()),
-        !isLoading && config && React.createElement(Footer, {
+        currentPage !== 'password-update' && !isLoading && config && React.createElement(Footer, {
             key: "footer",
             config: config
         }),

--- a/js/App.js
+++ b/js/App.js
@@ -8,6 +8,7 @@ import { LoginPage } from './components/pages/LoginPage.js';
 import { ResetPasswordPage } from './components/pages/ResetPasswordPage.js';
 import { DashboardPage } from './components/pages/DashboardPage.js';
 import { DocumentsPage } from './components/pages/DocumentsPage.js';
+import { PasswordUpdatePage } from './components/pages/PasswordUpdatePage.js';
 import { CalendarPage } from './components/pages/CalendarPage.js';
 import { AccountPage } from './components/pages/AccountPage.js';
 import { AdminPage } from './components/pages/AdminPage.js';
@@ -56,6 +57,10 @@ export const App = () => {
 
         const { data: authListener } = window.supabaseClient.auth.onAuthStateChange(
             async (event, session) => {
+                if (event === 'PASSWORD_RECOVERY') {
+                    setCurrentPage('password-update');
+                    return;
+                }
                 if (session?.user) {
                     const { data: userData } = await window.supabaseClient
                         .from('users')
@@ -78,6 +83,15 @@ export const App = () => {
             authListener.subscription.unsubscribe();
             try { window.supabaseClient.removeChannel(cfgChannel); } catch (_) {}
         };
+    }, []);
+
+    useEffect(() => {
+        try {
+            const hash = window.location.hash || '';
+            if (hash.includes('type=recovery')) {
+                setCurrentPage('password-update');
+            }
+        } catch (_) {}
     }, []);
 
     useEffect(() => {
@@ -181,6 +195,12 @@ export const App = () => {
                 });
             case 'reset-password':
                 return React.createElement(ResetPasswordPage, {
+                    theme: activeTheme,
+                    showNotification: showNotification,
+                    onNavigate: navigate
+                });
+            case 'password-update':
+                return React.createElement(PasswordUpdatePage, {
                     theme: activeTheme,
                     showNotification: showNotification,
                     onNavigate: navigate

--- a/js/App.js
+++ b/js/App.js
@@ -88,7 +88,8 @@ export const App = () => {
     useEffect(() => {
         try {
             const hash = window.location.hash || '';
-            if (hash.includes('type=recovery')) {
+            const path = window.location.pathname || '/';
+            if (hash.includes('type=recovery') || path === '/password-update') {
                 setCurrentPage('password-update');
             }
         } catch (_) {}

--- a/js/App.js
+++ b/js/App.js
@@ -262,7 +262,7 @@ export const App = () => {
             message: notification,
             onDismiss: () => setNotification('')
         }),
-        !isLoading && config && React.createElement(Header, {
+        currentPage !== 'password-update' && !isLoading && config && React.createElement(Header, {
             key: "header",
             config: config,
             theme: activeTheme,

--- a/js/App.js
+++ b/js/App.js
@@ -23,6 +23,9 @@ export const App = () => {
     const [currentPage, setCurrentPage] = useState('home');
     const [userRole, setUserRole] = useState(null);
     const [user, setUser] = useState(null);
+    const [recoveryMode, setRecoveryMode] = useState(false);
+    const [accountInitialTab, setAccountInitialTab] = useState(null);
+    const [restrictSecurityOnly, setRestrictSecurityOnly] = useState(false);
     const [themeName, setThemeName] = useState('blue');
     const [config, setConfig] = useState(null);
     const [notification, setNotification] = useState('');
@@ -58,7 +61,10 @@ export const App = () => {
         const { data: authListener } = window.supabaseClient.auth.onAuthStateChange(
             async (event, session) => {
                 if (event === 'PASSWORD_RECOVERY') {
-                    setCurrentPage('password-update');
+                    setRecoveryMode(true);
+                    setAccountInitialTab('security');
+                    setRestrictSecurityOnly(true);
+                    setCurrentPage('account');
                     return;
                 }
                 if (session?.user) {
@@ -89,7 +95,12 @@ export const App = () => {
         try {
             const hash = window.location.hash || '';
             const path = window.location.pathname || '/';
-            if (hash.includes('type=recovery') || path === '/password-update') {
+            if (hash.includes('type=recovery')) {
+                setRecoveryMode(true);
+                setAccountInitialTab('security');
+                setRestrictSecurityOnly(true);
+                setCurrentPage('account');
+            } else if (path === '/password-update') {
                 setCurrentPage('password-update');
             }
         } catch (_) {}
@@ -157,7 +168,7 @@ export const App = () => {
         
         // Page Access Guards
         const memberPages = ['dashboard', 'documents', 'calendar', 'account', 'admin'];
-        if (memberPages.includes(currentPage) && !userRole) {
+        if (memberPages.includes(currentPage) && !userRole && !(recoveryMode && currentPage === 'account')) {
             return React.createElement(LoginPage, {
                 theme: activeTheme,
                 onLogin: handleLogin,
@@ -233,7 +244,10 @@ export const App = () => {
                     user: user,
                     setUser: setUser,
                     showNotification: showNotification,
-                    onNavigate: navigate
+                    onNavigate: navigate,
+                    initialTab: accountInitialTab || undefined,
+                    restrictSecurityOnly: restrictSecurityOnly,
+                    recoveryMode: recoveryMode
                 });
             case 'admin':
                 return React.createElement(AdminPage, {

--- a/js/components/pages/AccountPage.js
+++ b/js/components/pages/AccountPage.js
@@ -388,7 +388,7 @@ export const AccountPage = ({ theme, user, setUser, showNotification, onNavigate
             key: "content",
             className: "grid lg:grid-cols-4 gap-8"
         }, [
-            React.createElement('div', {
+            !restrictSecurityOnly && React.createElement('div', {
                 key: "sidebar",
                 className: "lg:col-span-1"
             }, React.createElement('div', {

--- a/js/components/pages/AccountPage.js
+++ b/js/components/pages/AccountPage.js
@@ -371,7 +371,7 @@ export const AccountPage = ({ theme, user, setUser, showNotification, onNavigate
                     className: "text-xl text-gray-600"
                 }, "Manage your profile and preferences")
             ]),
-            React.createElement('button', {
+            !restrictSecurityOnly && React.createElement('button', {
                 key: "back-btn",
                 onClick: () => onNavigate('dashboard'),
                 className: "modern-button px-6 py-3 rounded-xl shadow-lg hover:shadow-xl transform hover:-translate-y-1"

--- a/js/components/pages/AccountPage.js
+++ b/js/components/pages/AccountPage.js
@@ -5,7 +5,7 @@ export const AccountPage = ({ theme, user, setUser, showNotification, onNavigate
     const [formData, setFormData] = useState(user || {});
     const [newPassword, setNewPassword] = useState('');
     const [confirmPassword, setConfirmPassword] = useState('');
-    const [activeTab, setActiveTab] = useState('profile');
+    const [activeTab, setActiveTab] = useState(initialTab || 'profile');
     const [showSaveConfirm, setShowSaveConfirm] = useState(false);
     const [showPasswordConfirm, setShowPasswordConfirm] = useState(false);
 

--- a/js/components/pages/AccountPage.js
+++ b/js/components/pages/AccountPage.js
@@ -415,7 +415,7 @@ export const AccountPage = ({ theme, user, setUser, showNotification, onNavigate
             ])),
             React.createElement('div', {
                 key: "main-content",
-                className: "lg:col-span-3"
+                className: restrictSecurityOnly ? "lg:col-span-4" : "lg:col-span-3"
             }, [
                 React.createElement('div', {
                     key: "tab-content",

--- a/js/components/pages/AccountPage.js
+++ b/js/components/pages/AccountPage.js
@@ -1,7 +1,7 @@
 import { ConfirmationModal } from '../ui/ConfirmationModal.js';
 const { useState } = React;
 
-export const AccountPage = ({ theme, user, setUser, showNotification, onNavigate }) => {
+export const AccountPage = ({ theme, user, setUser, showNotification, onNavigate, initialTab, restrictSecurityOnly, recoveryMode }) => {
     const [formData, setFormData] = useState(user || {});
     const [newPassword, setNewPassword] = useState('');
     const [confirmPassword, setConfirmPassword] = useState('');

--- a/js/components/pages/AccountPage.js
+++ b/js/components/pages/AccountPage.js
@@ -60,7 +60,12 @@ export const AccountPage = ({ theme, user, setUser, showNotification, onNavigate
                 setNewPassword('');
                 setConfirmPassword('');
                 setShowPasswordConfirm(true);
-                try { alert('Done'); } catch (_) {}
+                if (recoveryMode) {
+                    try { await window.supabaseClient.auth.signOut(); } catch (_) {}
+                    onNavigate('login');
+                } else {
+                    try { alert('Done'); } catch (_) {}
+                }
             }
         } catch (error) {
             showNotification("Error changing password.");

--- a/js/components/pages/AccountPage.js
+++ b/js/components/pages/AccountPage.js
@@ -421,7 +421,7 @@ export const AccountPage = ({ theme, user, setUser, showNotification, onNavigate
                     key: "tab-content",
                     className: "modern-card p-10"
                 }, renderTabContent()),
-                (activeTab === 'profile' || activeTab === 'notifications') && React.createElement('div', {
+                !restrictSecurityOnly && (activeTab === 'profile' || activeTab === 'notifications') && React.createElement('div', {
                     key: "save-section",
                     className: "mt-8 text-center"
                 }, React.createElement('button', {

--- a/js/components/pages/PasswordUpdatePage.js
+++ b/js/components/pages/PasswordUpdatePage.js
@@ -1,0 +1,80 @@
+const { useState } = React;
+
+export const PasswordUpdatePage = ({ theme, showNotification, onNavigate }) => {
+    const [newPassword, setNewPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleUpdatePassword = async () => {
+        if (newPassword !== confirmPassword) {
+            showNotification('New passwords do not match.');
+            return;
+        }
+        if (newPassword.length < 6) {
+            showNotification('Password must be at least 6 characters long.');
+            return;
+        }
+        try {
+            setIsLoading(true);
+            const { error } = await window.supabaseClient.auth.updateUser({ password: newPassword });
+            if (error) {
+                showNotification('Error updating password: ' + error.message);
+            } else {
+                showNotification('Password updated successfully. Please sign in with your new password.');
+                try { await window.supabaseClient.auth.signOut(); } catch (_) {}
+                onNavigate('login');
+            }
+        } catch (e) {
+            showNotification('Error updating password.');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return React.createElement('div', {
+        className: 'min-h-screen flex items-center justify-center fade-in p-6'
+    }, React.createElement('div', {
+        className: 'bg-white p-10 rounded-2xl shadow-xl w-full max-w-lg'
+    }, [
+        React.createElement('div', { key: 'header', className: 'text-center mb-10' }, [
+            React.createElement('div', { key: 'shield', className: 'bg-gradient-to-br from-red-100 to-rose-100 w-24 h-24 rounded-full mx-auto mb-6 flex items-center justify-center shadow-lg' },
+                React.createElement('i', { className: 'fas fa-shield-alt text-4xl text-red-700' })
+            ),
+            React.createElement('h1', { key: 'title', className: 'text-4xl font-bold text-gray-800' }, 'Security Settings'),
+            React.createElement('p', { key: 'subtitle', className: 'text-gray-600 mt-4' }, 'Set a new password to secure your account')
+        ]),
+        React.createElement('div', { key: 'form', className: 'space-y-6' }, [
+            React.createElement('div', { key: 'new-password', className: 'space-y-3' }, [
+                React.createElement('label', { key: 'new-password-label', className: 'block text-lg font-bold text-gray-700' }, 'New Password'),
+                React.createElement('input', {
+                    key: 'new-password-input',
+                    type: 'password',
+                    value: newPassword,
+                    onChange: (e) => setNewPassword(e.target.value),
+                    className: 'modern-input w-full text-lg',
+                    placeholder: 'Enter new password'
+                })
+            ]),
+            React.createElement('div', { key: 'confirm-password', className: 'space-y-3' }, [
+                React.createElement('label', { key: 'confirm-password-label', className: 'block text-lg font-bold text-gray-700' }, 'Confirm New Password'),
+                React.createElement('input', {
+                    key: 'confirm-password-input',
+                    type: 'password',
+                    value: confirmPassword,
+                    onChange: (e) => setConfirmPassword(e.target.value),
+                    className: 'modern-input w-full text-lg',
+                    placeholder: 'Confirm new password'
+                })
+            ]),
+            React.createElement('button', {
+                key: 'update-btn',
+                onClick: handleUpdatePassword,
+                disabled: isLoading,
+                className: `w-full bg-gradient-to-r from-red-500 to-rose-600 text-white font-bold py-4 px-6 rounded-2xl text-lg hover:from-red-600 hover:to-rose-700 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 disabled:opacity-50 disabled:cursor-not-allowed`
+            }, isLoading ? React.createElement('div', { className: 'loader mx-auto h-6 w-6' }) : React.createElement('div', { className: 'flex items-center justify-center gap-3' }, [
+                React.createElement('i', { key: 'key-icon', className: 'fas fa-key' }),
+                React.createElement('span', { key: 'btn-text' }, 'Update Password')
+            ]))
+        ])
+    ]));
+};

--- a/js/components/pages/ResetPasswordPage.js
+++ b/js/components/pages/ResetPasswordPage.js
@@ -7,7 +7,7 @@ export const ResetPasswordPage = ({ theme, showNotification, onNavigate }) => {
     const handlePasswordReset = async () => {
         setIsLoading(true);
         const { error } = await window.supabaseClient.auth.resetPasswordForEmail(email, {
-            redirectTo: `${window.location.origin}/password-update`,
+            redirectTo: `${window.location.origin}/account#type=recovery`,
         });
         if (error) {
             showNotification("Error: " + error.message);

--- a/js/components/pages/ResetPasswordPage.js
+++ b/js/components/pages/ResetPasswordPage.js
@@ -7,7 +7,7 @@ export const ResetPasswordPage = ({ theme, showNotification, onNavigate }) => {
     const handlePasswordReset = async () => {
         setIsLoading(true);
         const { error } = await window.supabaseClient.auth.resetPasswordForEmail(email, {
-            redirectTo: window.location.origin,
+            redirectTo: `${window.location.origin}/password-update`,
         });
         if (error) {
             showNotification("Error: " + error.message);


### PR DESCRIPTION
## Purpose
The user requested that password reset links should redirect to a dedicated security settings page instead of the general account page. They wanted the reset flow to take users directly to Account Settings / Security Settings with only the password update functionality visible, creating a focused experience for password recovery.

## Code changes
- **Added new PasswordUpdatePage component** for dedicated password reset interface
- **Modified ResetPasswordPage** to redirect to `/account#type=recovery` instead of homepage
- **Enhanced AccountPage** with recovery mode support:
  - Added `recoveryMode`, `restrictSecurityOnly`, and `initialTab` props
  - Automatically opens security tab and hides other sections in recovery mode
  - Signs out user after successful password change in recovery mode
- **Updated App.js routing** to handle password recovery flow:
  - Added URL hash detection for `type=recovery`
  - Added recovery mode state management
  - Modified page access guards to allow account page access during recovery
  - Hidden header/footer on password update page for cleaner UXTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/52780ac15ee643f386926c823198fc62/echo-haven)

👀 [Preview Link](https://52780ac15ee643f386926c823198fc62-echo-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>52780ac15ee643f386926c823198fc62</projectId>-->
<!--<branchName>echo-haven</branchName>-->